### PR TITLE
Add new lints for flutter 3.0.0 and metrics 4.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.0
+
+* Lints from dart_metrics version 4.15.2
+* Lints for Flutter 3.0.0
+* Fixed typos and updated docs
+
 ## 0.1.0
 
 * This is first version of miquido_flutter_lints

--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@ and the Flutter guide for
 # miquido_flutter_lints
 ##### This is collection of Flutter lints that we use and follow in [Miquido Software development company](https://www.miquido.com).
 
-This is strict, large and robust collection beacuse we strive for high quality code, good practices and we want follow the same coding style in all our mobile apps.
+This is strict, large and robust collection because we strive for high quality code, good practices and we want follow the same coding style in all our mobile apps.
 
 And we just looooove lots of lints. :blue_heart:
 
 ---
 ## Getting started
-We tested current configuration with this enviroment:
+We tested current configuration with this environment:
 ```yaml
 environment:
-  sdk: ">=2.16.1 <3.0.0"
-  flutter: ^2.10.3
+  sdk: ">=2.17.0 <3.0.0"
+  flutter: ^3.0.0
 ```
 
 so it is required to update your flutter project to meet this conditions.
@@ -43,7 +43,7 @@ dev_dependencies:
 
 or
 
-you can copy content of [this file](lib/miquido_lints.yaml) to your `analysis_options.yaml`. In this approach remember that you need to depend on `dart_code_metrics: 4.12.0`, and you will need to add that package to your `pubspec.yaml` as well. Also you will need to visit this repository from time to time to check for changes! 
+you can copy content of [this file](lib/miquido_lints.yaml) to your `analysis_options.yaml`. In this approach remember that you need to depend on `dart_code_metrics: 4.15.2`, and you will need to add that package to your `pubspec.yaml` as well. Also you will need to visit this repository from time to time to check for changes! 
 
 Also if you star this repo, that would be nice.
 

--- a/lib/miquido_lints.yaml
+++ b/lib/miquido_lints.yaml
@@ -89,7 +89,7 @@ linter:
     - curly_braces_in_flow_control_structures
     # - depend_on_referenced_packages - This will make you at some point add all pub.dev to your pubspec file. Maybe suitable for ultra small petprojets with one dependency at max.
     - deprecated_consistency
-    # - diagnostic_describe_all_properties - Add unncessary complexity to code and makes it difficult to read
+    # - diagnostic_describe_all_properties - Add unnecessary complexity to code and makes it difficult to read
     - directives_ordering
     - do_not_use_environment
     - empty_catches
@@ -212,7 +212,9 @@ linter:
     - unrelated_type_equality_checks
     - unsafe_html
     # - use_build_context_synchronously - this is mostly useful in some animations, but most of the time it unnecessary makes code more complex
+    - use_colored_box
     - use_decorated_box
+    - use_enums
     - use_full_hex_values_for_flutter_colors
     - use_function_type_syntax_for_parameters
     - use_if_null_to_convert_nulls_to_bools
@@ -224,6 +226,7 @@ linter:
     - use_rethrow_when_possible
     - use_setters_to_change_properties
     - use_string_buffers
+    - use_super_parameters
     - use_test_throws_matchers
     - use_to_and_as_if_applicable
     - valid_regexps
@@ -231,8 +234,8 @@ linter:
 
 # More about this additional linter here: https://dartcodemetrics.dev/docs/rules/overview
 # This is more strict linter, and it is very cool to follow it, but it is not mandatory to obey.
-# Only set of default rules above is manatory to resolve and pass pipeline
-# to exectute run `flutter analyze`. It should show "No issues found!" message.
+# Only set of default rules above is mandatory to resolve and pass pipeline
+# to execute run `flutter analyze`. It should show "No issues found!" message.
 dart_code_metrics:
   rules:
     - avoid-collection-methods-with-unrelated-types
@@ -242,6 +245,7 @@ dart_code_metrics:
     # - avoid-late-keyword - makes no sense
     - avoid-missing-enum-constant-in-map
     - avoid-nested-conditional-expressions
+    - avoid-non-ascii-symbols
     # - avoid-non-null-assertion - this is good lint, but sometimes is unfixable
     # - avoid-throw-in-catch-block - enabling it only because of provided justification in our opinion is just flexing
     - avoid-unnecessary-type-assertions
@@ -275,35 +279,39 @@ dart_code_metrics:
     # - no-magic-number - disabled as it makes you extract each height, width (and similar properties) value to separate variables 
     - no-object-declaration
     - prefer-async-await
-    # - prefer-conditional-expressions - disabled as sometimes this condition is not as readible as you would expected
+    - prefer-commenting-analyzer-ignores
+    # - prefer-conditional-expressions - disabled as sometimes this condition is not as readable as you would expected
     - prefer-correct-identifier-length:
         exceptions: ['i', 'x', 'id', 'db']
         min-identifier-length: 3
         max-identifier-length: 35
     - prefer-correct-type-name
     # - prefer-first - disabled as oldschool array[0] is clearer
+    - prefer-immediate-return
     - prefer-last # but this one is much better that array[array.length-1]
     - prefer-match-file-name:
         severity: error
         exclude:
           - test/**
     # - prefer-trailing-comma - this one is pure hardcore and too strict
+    - prefer-moving-to-variable
     - tag-name:
         exclude:
           - test/**
     - always-remove-listener
-    # - avoid-border-all - proposed solution is adding extra code complexiticy for meaningless profit
+    # - avoid-border-all - proposed solution is adding extra code complexity for meaningless profit
     - avoid-returning-widgets:
         severity: error
     - avoid-unnecessary-setstate
     - avoid-wrapping-in-padding
-    # - prefer-const-border-radius - proposed solution is adding extra code complexiticy for meaningless profit
+    # - prefer-const-border-radius - proposed solution is adding extra code complexity for meaningless profit
     - prefer-extracting-callbacks:
         ignored-named-arguments:
           - listener
           - listenWhen
           - buildWhen
           - itemBuilder
+          - builder
     - prefer-single-widget-per-file:
         ignore-private-widgets: true
     - prefer-intl-name
@@ -335,3 +343,4 @@ dart_code_metrics:
         severity: warning
         exclude:
           - test/**
+    - long-parameter-list

--- a/lib/miquido_lints.yaml
+++ b/lib/miquido_lints.yaml
@@ -39,7 +39,7 @@ linter:
     - avoid_bool_literals_in_conditional_expressions
     - avoid_catches_without_on_clauses
     - avoid_catching_errors
-    # - avoid_classes_with_only_static_members - We know, but somewhat this doesnt fell right and clean
+    # - avoid_classes_with_only_static_members - We know, but somewhat this doesn't fell right and clean
     - avoid_double_and_int_checks
     - avoid_dynamic_calls
     - avoid_empty_else
@@ -241,12 +241,12 @@ dart_code_metrics:
     - avoid-collection-methods-with-unrelated-types
     # - avoid-dynamic - as much as we would love to have it, sometimes it is necessary
     - avoid-global-state
-    # - avoid-ignoring-return-values - sometimes method return something, but you dont care, and that is ok
+    # - avoid-ignoring-return-values - sometimes method return something, but you don't care, and that is ok
     # - avoid-late-keyword - makes no sense
     - avoid-missing-enum-constant-in-map
     - avoid-nested-conditional-expressions
-    - avoid-non-ascii-symbols
-    # - avoid-non-null-assertion - this is good lint, but sometimes is unfixable
+    # - avoid-non-ascii-symbols - this warns about emojis, currency symbols (sometimes needed, makes no sense to use or to ignore every time)
+    # - avoid-non-null-assertion - this is good lint, but sometimes is un-fixable
     # - avoid-throw-in-catch-block - enabling it only because of provided justification in our opinion is just flexing
     - avoid-unnecessary-type-assertions
     - avoid-unnecessary-type-casts
@@ -286,7 +286,7 @@ dart_code_metrics:
         min-identifier-length: 3
         max-identifier-length: 35
     - prefer-correct-type-name
-    # - prefer-first - disabled as oldschool array[0] is clearer
+    # - prefer-first - disabled as old-school array[0] is clearer
     - prefer-immediate-return
     - prefer-last # but this one is much better that array[array.length-1]
     - prefer-match-file-name:
@@ -294,7 +294,7 @@ dart_code_metrics:
         exclude:
           - test/**
     # - prefer-trailing-comma - this one is pure hardcore and too strict
-    - prefer-moving-to-variable
+    # - prefer-moving-to-variable - as of usage Theme.of(context) this lights up for every textTheme style used in one widget used
     - tag-name:
         exclude:
           - test/**

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,14 @@
 name: miquido_flutter_lints
 description: Collection of Flutter lints that we use and follow in Miquido
-version: 0.1.0
+version: 0.2.0
 homepage: https://www.miquido.com
 
 environment:
-  sdk: ">=2.16.1 <3.0.0"
-  flutter: ">=2.10.3"
+  sdk: ">=2.17.0 <3.0.0"
+  flutter: ^3.0.0
 
 dependencies:
-  dart_code_metrics: 4.12.0
+  dart_code_metrics: 4.15.2
   
   flutter:
     sdk: flutter


### PR DESCRIPTION
New lints:
- https://dart-lang.github.io/linter/lints/use_colored_box.html
- https://dart-lang.github.io/linter/lints/use_enums.html
- https://dart-lang.github.io/linter/lints/use_super_parameters.html
- https://dartcodemetrics.dev/docs/rules/common/avoid-non-ascii-symbols
- https://dartcodemetrics.dev/docs/rules/common/prefer-commenting-analyzer-ignores
- https://dartcodemetrics.dev/docs/rules/common/prefer-immediate-return
- https://dartcodemetrics.dev/docs/rules/common/prefer-moving-to-variable - I think this might be discussed as of using `Theme.of(context)`
- https://dartcodemetrics.dev/docs/anti-patterns/long-parameter-list