### PR TITLE
Flutter 3.10, Dart 3 and updated DCM version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+* Removed `implicit-casts` and `implicit-dynamic` rules deprecated in Dart 3
+* Added`avoid-substring` rule from dart_code_metrics version 5.7.3
+
 ## 1.0.0
 
 * Lints from dart_metrics version 5.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 1.0.1
+## 1.10.0
+* Lints from dart_metrics version 5.7.3
+* Lints for Flutter 3.10.0 and Dart 3.0.0
 * Removed `implicit-casts` and `implicit-dynamic` rules deprecated in Dart 3
 * Added `avoid-substring` rule from dart_code_metrics version 5.7.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.1
 * Removed `implicit-casts` and `implicit-dynamic` rules deprecated in Dart 3
-* Added`avoid-substring` rule from dart_code_metrics version 5.7.3
+* Added `avoid-substring` rule from dart_code_metrics version 5.7.3
 
 ## 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ And we just looooove lots of lints. :blue_heart:
 For a start please make sure you work with latest version of Flutter & Dart.
 ```yaml
 environment:
-  sdk: ">=2.19.2 <3.0.0"
-  flutter: ^3.7.7
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ^3.10.0
 ```
 
 Then add a dev dependency in your `pubspec.yaml`:
@@ -40,7 +40,7 @@ or directly in pubspec.yaml
 
 ```yaml
 dev_dependencies:
-  lint_quido: 1.0.0
+  lint_quido: 1.10.0
 ```
 
 At last in `analysis_options.yaml` add:

--- a/lib/miquido_lints.yaml
+++ b/lib/miquido_lints.yaml
@@ -1,11 +1,6 @@
 analyzer:
   plugins:
     - dart_code_metrics
-
-  # Explanation for this settings are described in Step 3 of this https://dash-overflow.net/articles/getting_started/
-  strong-mode:
-    implicit-casts: false
-    implicit-dynamic: false
   
   exclude:
     - "**/*.g.dart"
@@ -263,6 +258,7 @@ dart_code_metrics:
     # - avoid-passing-async-when-sync-expected - doesn't go well with lambda expressions, onPressed or freezed
     - avoid-redundant-async:
         severity: info
+    - avoid-substring
     # - avoid-throw-in-catch-block - enabling it because of provided justification in our opinion is just flexing
     - avoid-top-level-members-in-tests:
         exclude:

--- a/lib/miquido_lints.yaml
+++ b/lib/miquido_lints.yaml
@@ -84,6 +84,7 @@ linter:
     - dangling_library_doc_comments
     # - depend_on_referenced_packages - This will make you at some point add all pub.dev to your pubspec file. Maybe suitable for ultra small pet projects with one dependency at max.
     - deprecated_consistency
+    - deprecated_member_use_from_same_package
     # - diagnostic_describe_all_properties - Add unnecessary complexity to code and makes it difficult to read
     - directives_ordering
     # - discarded_futures - do not work well with testing tools and cascade operator
@@ -98,6 +99,8 @@ linter:
     - hash_and_equals
     - implementation_imports
     - implicit_call_tearoffs
+    - implicit_reopen
+    - invalid_case_patterns
     - iterable_contains_unrelated_type
     - join_return_with_assignment
     - leading_newlines_in_multiline_strings
@@ -108,12 +111,14 @@ linter:
     # - lines_longer_than_80_chars - In Miquido there are two teams: 100 or 120. One of them is wrong.
     - list_remove_unrelated_type
     - literal_only_boolean_expressions
+    - matching_super_parameters
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list
     - no_default_cases
     - no_duplicate_case_values
     - no_leading_underscores_for_library_prefixes
     - no_leading_underscores_for_local_identifiers
+    - no_literal_bool_comparisons
     - no_logic_in_create_state
     - no_runtimeType_toString
     - non_constant_identifier_names
@@ -184,9 +189,11 @@ linter:
     - tighten_type_of_initializing_formals
     - type_annotate_public_apis
     - type_init_formals
+    - type_literal_in_constant_pattern
     - unawaited_futures
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
+    - unnecessary_breaks
     - unnecessary_const
     - unnecessary_constructor_name
     # - unnecessary_final - absurd justification for this one
@@ -211,7 +218,7 @@ linter:
     - unreachable_from_main
     - unrelated_type_equality_checks
     - unsafe_html
-    # - use_build_context_synchronously - this is mostly useful in some animations, but most of the time it unnecessary makes code more complex
+    - use_build_context_synchronously
     - use_colored_box
     - use_decorated_box
     - use_enums

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: lint_quido
-version: 1.0.0
+version: 1.0.1
 description: Collection of Flutter lints that we use and follow in Miquido
 repository: https://github.com/miquido/lint_quido
 issue_tracker: https://github.com/miquido/lint_quido/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: lint_quido
-version: 1.0.1
+version: 1.10.0
 description: Collection of Flutter lints that we use and follow in Miquido
 repository: https://github.com/miquido/lint_quido
 issue_tracker: https://github.com/miquido/lint_quido/issues
@@ -7,7 +7,7 @@ homepage: https://github.com/miquido/lint_quido
 documentation: https://github.com/miquido/lint_quido
 
 environment:
-  sdk: ">=2.19.2 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
   flutter: ">=3.10.0"
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,10 +8,10 @@ documentation: https://github.com/miquido/lint_quido
 
 environment:
   sdk: ">=2.19.2 <3.0.0"
-  flutter: ">=3.7.7"
+  flutter: ">=3.10.0"
 
 dependencies:
-  dart_code_metrics: ^5.6.0
+  dart_code_metrics: ^5.7.3
   
   flutter:
     sdk: flutter


### PR DESCRIPTION
`implicit-casts` and `implicit-dynamic` rules were removed from `analysis_options` since they are no longer supported in Dart 3.

With the new rules in the latest DCM version, there is one worth considering: [`avoid-substring`](https://dcm.dev/docs/individuals/rules/common/avoid-substring/)