### PR TITLE
Add new lints for Flutter 3.16.2 and metrics 5.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.16.0
+* Lints from dart_metrics version 5.7.6
+* Lints for Flutter 3.16.2 and Dart 3.2.2
+* :warning: This version is based on discontinued DCM version
+
 ## 1.13.2
 * Lints from dart_metrics version 5.7.6
 * Lints for Flutter 3.13.0 and Dart 3.0.6

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ And we just looooove lots of lints. :blue_heart:
 For a start please make sure you work with latest version of Flutter & Dart.
 ```yaml
 environment:
-  sdk: ">=3.0.6 <4.0.0"
-  flutter: ^3.13.2
+  sdk: ">=3.2.2 <4.0.0"
+  flutter: ^3.16.2
 ```
 
 Then add a dev dependency in your `pubspec.yaml`:
@@ -40,7 +40,7 @@ or directly in pubspec.yaml
 
 ```yaml
 dev_dependencies:
-  lint_quido: 1.13.2
+  lint_quido: 1.16.0
 ```
 
 At last in `analysis_options.yaml` add:
@@ -118,7 +118,7 @@ This is set of sources from which we are getting our linters and about good prac
 - [Customizing static analysis in Dart](https://dart.dev/tools/analysis)
 - [Effective Dart: Usage](https://dart.dev/guides/language/effective-dart/usage)
 - [Flutter lints](https://github.com/flutter/packages/tree/main/packages/flutter_lints)
-- [Dart metrics](https://dcm.dev/docs/individuals/rules/)
+- [Dart Code Metrics](https://dcm.dev/docs/rules/)
 - [Dart language type system](https://github.com/dart-lang/language/tree/main/resources/type-system)
 
 ---

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,10 +1,10 @@
 name: lint_quido_example
-version: 1.0.0
+version: 1.16.0
 publish_to: none
 
 environment:
-  sdk: ">=3.0.6 <4.0.0"
-  flutter: ">=3.13.1"
+  sdk: ">=3.2.2 <4.0.0"
+  flutter: ">=3.16.2"
 
 dependencies:
   lint_quido:

--- a/lib/miquido_lints.yaml
+++ b/lib/miquido_lints.yaml
@@ -30,6 +30,7 @@ linter:
     # - always_specify_types - Incompatible with avoid_types_on_closure_parameters, which we prefer
     - always_use_package_imports
     - annotate_overrides
+    - annotate_redeclares
     # - avoid_annotating_with_dynamic - Super problematic to fix with avoid_types_on_closure_parameters enabled
     - avoid_bool_literals_in_conditional_expressions
     # - avoid_catches_without_on_clauses - Flutter throws _CastError when parsing json fails, so we need to handle both Error and Exception in all API classes
@@ -104,7 +105,6 @@ linter:
     - implicit_call_tearoffs
     - implicit_reopen
     - invalid_case_patterns
-    - iterable_contains_unrelated_type
     - join_return_with_assignment
     - leading_newlines_in_multiline_strings
     - library_annotations
@@ -112,7 +112,6 @@ linter:
     - library_prefixes
     # - library_private_types_in_public_api - Disabled as any stateful widget triggers it
     # - lines_longer_than_80_chars - In Miquido there are two teams: 100 or 120. One of them is wrong.
-    - list_remove_unrelated_type
     - literal_only_boolean_expressions
     - matching_super_parameters
     - missing_whitespace_between_adjacent_strings
@@ -150,7 +149,7 @@ linter:
     - prefer_constructors_over_static_methods
     - prefer_contains
     # - prefer_double_quotes - We prefer_single_quotes
-    # - prefer_expression_function_bodies - We like mix of return and =>
+    # - prefer_expression_function_bodies - We like mix of return and => and that is ok
     - prefer_final_fields
     - prefer_final_in_for_each
     - prefer_final_locals
@@ -201,7 +200,7 @@ linter:
     - unnecessary_breaks
     - unnecessary_const
     - unnecessary_constructor_name
-    # - unnecessary_final - absurd justification for this one
+    # - unnecessary_final - we prefer_final_locals
     - unnecessary_getters_setters
     - unnecessary_lambdas
     - unnecessary_late

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: lint_quido
-version: 1.13.2
+version: 1.16.0
 description: Collection of Flutter lints that we use and follow in Miquido
 repository: https://github.com/miquido/lint_quido
 issue_tracker: https://github.com/miquido/lint_quido/issues
@@ -11,8 +11,8 @@ topics:
   - lints
 
 environment:
-  sdk: ">=3.0.6 <4.0.0"
-  flutter: ">=3.13.0"
+  sdk: ">=3.2.2 <4.0.0"
+  flutter: ">=3.16.2"
 
 platforms:
   android:


### PR DESCRIPTION
* Lints from dart_metrics version 5.7.6
* Lints for Flutter 3.16.2 and Dart 3.2.2

![image](https://github.com/miquido/lint_quido/assets/17902851/259d4be0-c03c-413e-b583-2118b185a1e7)
