### PR TITLE
Add new lints for flutter 3.22.3, dart 3.4.4 and metrics 5.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.22.3
+
+* Lints for Flutter 3.22.3 and Dart 3.4.4
+* Lints from dart_metrics version 5.7.6
+* :warning: This version is based on discontinued DCM version
+
 ## 1.19.0
 
 * Lints from dart_metrics version 5.7.6

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ And we just looooove lots of lints. :blue_heart:
 For a start please make sure you work with latest version of Flutter & Dart.
 ```yaml
 environment:
-  sdk: ">=3.2.2 <4.0.0"
-  flutter: ^3.16.2
+  sdk: ">=3.4.4 <4.0.0"
+  flutter: ^3.22.3
 ```
 
 Then add a dev dependency in your `pubspec.yaml`:
@@ -40,7 +40,7 @@ or directly in pubspec.yaml
 
 ```yaml
 dev_dependencies:
-  lint_quido: 1.16.0
+  lint_quido: 1.22.3
 ```
 
 At last in `analysis_options.yaml` add:
@@ -98,7 +98,7 @@ dart run dart_code_metrics:metrics check-unnecessary-nullable lib
 dart pub run dart_code_metrics:metrics check-unused-code lib
 ```
 
-[Here](https://dcm.dev/docs/individuals/cli/analyze/) you can find documentation about dart metrics commands.
+[Here](https://dcm.dev/docs/cli/) you can find documentation about dart metrics commands.
 
 ## Troubleshooting
 Sometimes working with cutting-edge versions might cause dependencies incompatibilities. For example `lint_quido` do not want to cooperate with test_api package or analyzer package and so on.

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,10 +1,10 @@
 name: lint_quido_example
-version: 1.19.0
+version: 1.22.3
 publish_to: none
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
-  flutter: ">=3.19.6"
+  sdk: ">=3.4.4 <4.0.0"
+  flutter: ">=3.22.3"
 
 dependencies:
   lint_quido:

--- a/lib/miquido_lints.yaml
+++ b/lib/miquido_lints.yaml
@@ -111,7 +111,7 @@ linter:
     # - lines_longer_than_80_chars - In Miquido there are two teams: 100 or 120. One of them is wrong.
     - literal_only_boolean_expressions
     - matching_super_parameters
-    # - missing_code_block_language_in_doc_comment - currently experimental and not yet available in a stable SDK.
+    - missing_code_block_language_in_doc_comment
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list
     - no_default_cases
@@ -193,7 +193,6 @@ linter:
     - type_init_formals
     - type_literal_in_constant_pattern
     - unawaited_futures
-    # - unintended_html_in_doc_comment - currently experimental and not yet available in a stable SDK.
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
     - unnecessary_breaks
@@ -204,7 +203,7 @@ linter:
     - unnecessary_lambdas
     - unnecessary_late
     - unnecessary_library_directive
-    # - unnecessary_library_name - currently experimental and not yet available in a stable SDK.
+    - unnecessary_library_name
     - unnecessary_new
     - unnecessary_null_aware_assignments
     - unnecessary_null_aware_operator_on_extension_on_nullable

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: lint_quido
-version: 1.19.0
+version: 1.22.3
 description: Collection of Flutter lints that we use and follow in Miquido
 repository: https://github.com/miquido/lint_quido
 issue_tracker: https://github.com/miquido/lint_quido/issues
@@ -11,8 +11,8 @@ topics:
   - lints
 
 environment:
-  sdk: ">=3.3.4 <4.0.0"
-  flutter: ">=3.19.6"
+  sdk: ">=3.4.4 <4.0.0"
+  flutter: ">=3.22.3"
 
 platforms:
   android:


### PR DESCRIPTION
* Lints for Flutter 3.22.3 and Dart 3.4.4
* Lints from dart_metrics version 5.7.6

![f7f2ed11-7b4c-4370-9016-4805a569f70a_text](https://github.com/user-attachments/assets/a4ec22bb-7eb9-4915-a6cb-1915877504e8)
